### PR TITLE
Update gh-pages

### DIFF
--- a/simulator/assembler.js
+++ b/simulator/assembler.js
@@ -728,7 +728,7 @@ function SimulatorWidget(node) {
       },
 
       i45: function () {
-        var addr = (popByte() + regX) & 0xff;
+        var addr = popByte() & 0xff;
         var value = memory.get(addr);
         regA ^= value;
         EOR();


### PR DESCRIPTION
The instruction "EOR operand" (code $45) shouldn't use the X register when addressing memory. 
Code to reproduce the bug:
ldx #5
lda #$11
sta 2
lda #$21
eor 2
sta 1

Expected result: value $30 at address $0001
Observed result: value $21
