### PR TITLE
fixup RTS carry into high byte of PC

### DIFF
--- a/simulator/assembler.js
+++ b/simulator/assembler.js
@@ -865,7 +865,7 @@ function SimulatorWidget(node) {
       },
 
       i60: function () {
-        regPC = (stackPop() + 1) | (stackPop() << 8);
+        regPC = (stackPop() | (stackPop() << 8)) + 1;
         //RTS
       },
 


### PR DESCRIPTION
This fixes the issue with RTS.
Test case:
jmp $7fd
*=$7fd
jsr tst
nop
tst:
rts
