### PR TITLE
Added modified assembler with preprocessor facility and adapted Snake650...

### DIFF
--- a/_includes/snake.html
+++ b/_includes/snake.html
@@ -6,11 +6,30 @@
 
 ; Change direction: W A S D
 
-; $00-01 => screen location of apple
-; $10-11 => screen location of snake head
-; $12-?? => snake body (in byte pairs)
-; $02    => direction (1 => up, 2 => right, 4 => down, 8 => left)
-; $03    => snake length
+define appleL    $00 ; screen location of apple
+define appleH    $01
+define headL     $10 ; screen location of snake head
+define headH     $11
+define body      $12 ; snake body (in byte pairs)
+define direction $02 ; direction (values are below)
+define length    $03 ; snake length
+
+; Directions (each using a separate bit)
+define movingUp     #1
+define movingRight  #2
+define movingDown   #4
+define movingLeft   #8
+
+; ASCII values of keys controlling the snake
+define ASCII_w   #$77
+define ASCII_a   #$61
+define ASCII_s   #$73
+define ASCII_d   #$64
+
+; System variables
+define random    $fe
+define lastKey   $ff
+define screen    $200
 
 
   jsr init
@@ -23,34 +42,39 @@ init:
 
 
 initSnake:
-  lda #2  ;start direction
-  sta $02
-  lda #4  ;start length
-  sta $03
+  lda {movingRight}  ;start direction
+  sta {direction}
+
+  lda #4  ;start length (2 segments)
+  sta {length}
+  
   lda #$11
-  sta $10
+  sta {headL}
+  
   lda #$10
-  sta $12
+  sta {body}
+  
   lda #$0f
-  sta $14
+  sta $14 ; body segment 1
+  
   lda #$04
-  sta $11
-  sta $13
-  sta $15
+  sta {headH}
+  sta $13 ; body segment 1
+  sta $15 ; body segment 2
   rts
 
 
 generateApplePosition:
   ;load a new random byte into $00
-  lda $fe
-  sta $00
+  lda {random}
+  sta {appleL}
 
   ;load a new random number from 2 to 5 into $01
-  lda $fe
+  lda {random}
   and #$03 ;mask out lowest 2 bits
   clc
   adc #2
-  sta $01
+  sta {appleH}
 
   rts
 
@@ -66,47 +90,47 @@ loop:
 
 
 readKeys:
-  lda $ff
-  cmp #$77
+  lda {lastKey}
+  cmp {ASCII_w}
   beq upKey
-  cmp #$64
+  cmp {ASCII_d}
   beq rightKey
-  cmp #$73
+  cmp {ASCII_s}
   beq downKey
-  cmp #$61
+  cmp {ASCII_a}
   beq leftKey
   rts
 upKey:
-  lda #4
-  bit $02
+  lda {movingDown}
+  bit {direction}
   bne illegalMove
 
-  lda #1
-  sta $02
+  lda {movingUp}
+  sta {direction}
   rts
 rightKey:
-  lda #8
-  bit $02
+  lda {movingLeft}
+  bit {direction}
   bne illegalMove
 
-  lda #2
-  sta $02
+  lda {movingRight}
+  sta {direction}
   rts
 downKey:
-  lda #1
-  bit $02
+  lda {movingUp}
+  bit {direction}
   bne illegalMove
 
-  lda #4
-  sta $02
+  lda {movingDown}
+  sta {direction}
   rts
 leftKey:
-  lda #2
-  bit $02
+  lda {movingRight}
+  bit {direction}
   bne illegalMove
 
-  lda #8
-  sta $02
+  lda {movingLeft}
+  sta {direction}
   rts
 illegalMove:
   rts
@@ -119,16 +143,16 @@ checkCollision:
 
 
 checkAppleCollision:
-  lda $00
-  cmp $10
+  lda {appleL}
+  cmp {headL}
   bne doneCheckingAppleCollision
-  lda $01
-  cmp $11
+  lda {appleH}
+  cmp {headH}
   bne doneCheckingAppleCollision
 
   ;eat apple
-  inc $03
-  inc $03 ;increase length
+  inc {length}
+  inc {length} ;increase length
   jsr generateApplePosition
 doneCheckingAppleCollision:
   rts
@@ -137,19 +161,19 @@ doneCheckingAppleCollision:
 checkSnakeCollision:
   ldx #2 ;start with second segment
 snakeCollisionLoop:
-  lda $10,x
-  cmp $10
+  lda {headL},x
+  cmp {headL}
   bne continueCollisionLoop
 
 maybeCollided:
-  lda $11,x
-  cmp $11
+  lda {headH},x
+  cmp {headH}
   beq didCollide
 
 continueCollisionLoop:
   inx
   inx
-  cpx $03          ;got to last section with no collision
+  cpx {length}          ;got to last section with no collision
   beq didntCollide
   jmp snakeCollisionLoop
 
@@ -160,16 +184,16 @@ didntCollide:
 
 
 updateSnake:
-  ldx $03 ;location of length
+  ldx {length} ;location of length
   dex
   txa
 updateloop:
-  lda $10,x
-  sta $12,x
+  lda {headL},x
+  sta {body},x
   dex
   bpl updateloop
 
-  lda $02
+  lda {direction}
   lsr
   bcs up
   lsr
@@ -179,40 +203,40 @@ updateloop:
   lsr
   bcs left
 up:
-  lda $10
+  lda {headL}
   sec
   sbc #$20
-  sta $10
+  sta {headL}
   bcc upup
   rts
 upup:
-  dec $11
+  dec {headH}
   lda #$1
-  cmp $11
+  cmp {headH}
   beq collision
   rts
 right:
-  inc $10
+  inc {headL}
   lda #$1f
-  bit $10
+  bit {headL}
   beq collision
   rts
 down:
-  lda $10
+  lda {headL}
   clc
   adc #$20
-  sta $10
+  sta {headL}
   bcs downdown
   rts
 downdown:
-  inc $11
+  inc {headH}
   lda #$6
-  cmp $11
+  cmp {headH}
   beq collision
   rts
 left:
-  dec $10
-  lda $10
+  dec {headL}
+  lda {headL}
   and #$1f
   cmp #$1f
   beq collision
@@ -223,18 +247,19 @@ collision:
 
 drawApple:
   ldy #0
-  lda $fe
-  sta ($00),y
+  lda {random}
+  sta ({appleL}),y
   rts
 
 
 drawSnake:
   ldx #0
   lda #1
-  sta ($10,x)
-  ldx $03
+  sta ({headL},x) ; paint head
+  
+  ldx {length}
   lda #0
-  sta ($10,x)
+  sta ({headL},x) ; erase end of tail
   rts
 
 

--- a/_includes/snake.html
+++ b/_includes/snake.html
@@ -6,30 +6,29 @@
 
 ; Change direction: W A S D
 
-define appleL    $00 ; screen location of apple
-define appleH    $01
-define headL     $10 ; screen location of snake head
-define headH     $11
-define body      $12 ; snake body (in byte pairs)
-define direction $02 ; direction (values are below)
-define length    $03 ; snake length
+define appleL         $00 ; screen location of apple, low byte
+define appleH         $01 ; screen location of apple, high byte
+define snakeHeadL     $10 ; screen location of snake head, low byte
+define snakeHeadH     $11 ; screen location of snake head, high byte
+define snakeBodyStart $12 ; start of snake body byte pairs
+define snakeDirection $02 ; direction (possible values are below)
+define snakeLength    $03 ; snake length, in bytes
 
 ; Directions (each using a separate bit)
-define movingUp     #1
-define movingRight  #2
-define movingDown   #4
-define movingLeft   #8
+define movingUp      1
+define movingRight   2
+define movingDown    4
+define movingLeft    8
 
 ; ASCII values of keys controlling the snake
-define ASCII_w   #$77
-define ASCII_a   #$61
-define ASCII_s   #$73
-define ASCII_d   #$64
+define ASCII_w      $77
+define ASCII_a      $61
+define ASCII_s      $73
+define ASCII_d      $64
 
 ; System variables
-define random    $fe
-define lastKey   $ff
-define screen    $200
+define sysRandom    $fe
+define sysLastKey   $ff
 
 
   jsr init
@@ -42,23 +41,23 @@ init:
 
 
 initSnake:
-  lda {movingRight}  ;start direction
-  sta {direction}
+  lda #movingRight  ;start direction
+  sta snakeDirection
 
   lda #4  ;start length (2 segments)
-  sta {length}
+  sta snakeLength
   
   lda #$11
-  sta {headL}
+  sta snakeHeadL
   
   lda #$10
-  sta {body}
+  sta snakeBodyStart
   
   lda #$0f
   sta $14 ; body segment 1
   
   lda #$04
-  sta {headH}
+  sta snakeHeadH
   sta $13 ; body segment 1
   sta $15 ; body segment 2
   rts
@@ -66,15 +65,15 @@ initSnake:
 
 generateApplePosition:
   ;load a new random byte into $00
-  lda {random}
-  sta {appleL}
+  lda sysRandom
+  sta appleL
 
   ;load a new random number from 2 to 5 into $01
-  lda {random}
+  lda sysRandom
   and #$03 ;mask out lowest 2 bits
   clc
   adc #2
-  sta {appleH}
+  sta appleH
 
   rts
 
@@ -90,47 +89,47 @@ loop:
 
 
 readKeys:
-  lda {lastKey}
-  cmp {ASCII_w}
+  lda sysLastKey
+  cmp #ASCII_w
   beq upKey
-  cmp {ASCII_d}
+  cmp #ASCII_d
   beq rightKey
-  cmp {ASCII_s}
+  cmp #ASCII_s
   beq downKey
-  cmp {ASCII_a}
+  cmp #ASCII_a
   beq leftKey
   rts
 upKey:
-  lda {movingDown}
-  bit {direction}
+  lda #movingDown
+  bit snakeDirection
   bne illegalMove
 
-  lda {movingUp}
-  sta {direction}
+  lda #movingUp
+  sta snakeDirection
   rts
 rightKey:
-  lda {movingLeft}
-  bit {direction}
+  lda #movingLeft
+  bit snakeDirection
   bne illegalMove
 
-  lda {movingRight}
-  sta {direction}
+  lda #movingRight
+  sta snakeDirection
   rts
 downKey:
-  lda {movingUp}
-  bit {direction}
+  lda #movingUp
+  bit snakeDirection
   bne illegalMove
 
-  lda {movingDown}
-  sta {direction}
+  lda #movingDown
+  sta snakeDirection
   rts
 leftKey:
-  lda {movingRight}
-  bit {direction}
+  lda #movingRight
+  bit snakeDirection
   bne illegalMove
 
-  lda {movingLeft}
-  sta {direction}
+  lda #movingLeft
+  sta snakeDirection
   rts
 illegalMove:
   rts
@@ -143,16 +142,16 @@ checkCollision:
 
 
 checkAppleCollision:
-  lda {appleL}
-  cmp {headL}
+  lda appleL
+  cmp snakeHeadL
   bne doneCheckingAppleCollision
-  lda {appleH}
-  cmp {headH}
+  lda appleH
+  cmp snakeHeadH
   bne doneCheckingAppleCollision
 
   ;eat apple
-  inc {length}
-  inc {length} ;increase length
+  inc snakeLength
+  inc snakeLength ;increase length
   jsr generateApplePosition
 doneCheckingAppleCollision:
   rts
@@ -161,19 +160,19 @@ doneCheckingAppleCollision:
 checkSnakeCollision:
   ldx #2 ;start with second segment
 snakeCollisionLoop:
-  lda {headL},x
-  cmp {headL}
+  lda snakeHeadL,x
+  cmp snakeHeadL
   bne continueCollisionLoop
 
 maybeCollided:
-  lda {headH},x
-  cmp {headH}
+  lda snakeHeadH,x
+  cmp snakeHeadH
   beq didCollide
 
 continueCollisionLoop:
   inx
   inx
-  cpx {length}          ;got to last section with no collision
+  cpx snakeLength          ;got to last section with no collision
   beq didntCollide
   jmp snakeCollisionLoop
 
@@ -184,16 +183,16 @@ didntCollide:
 
 
 updateSnake:
-  ldx {length} ;location of length
+  ldx snakeLength
   dex
   txa
 updateloop:
-  lda {headL},x
-  sta {body},x
+  lda snakeHeadL,x
+  sta snakeBodyStart,x
   dex
   bpl updateloop
 
-  lda {direction}
+  lda snakeDirection
   lsr
   bcs up
   lsr
@@ -203,40 +202,40 @@ updateloop:
   lsr
   bcs left
 up:
-  lda {headL}
+  lda snakeHeadL
   sec
   sbc #$20
-  sta {headL}
+  sta snakeHeadL
   bcc upup
   rts
 upup:
-  dec {headH}
+  dec snakeHeadH
   lda #$1
-  cmp {headH}
+  cmp snakeHeadH
   beq collision
   rts
 right:
-  inc {headL}
+  inc snakeHeadL
   lda #$1f
-  bit {headL}
+  bit snakeHeadL
   beq collision
   rts
 down:
-  lda {headL}
+  lda snakeHeadL
   clc
   adc #$20
-  sta {headL}
+  sta snakeHeadL
   bcs downdown
   rts
 downdown:
-  inc {headH}
+  inc snakeHeadH
   lda #$6
-  cmp {headH}
+  cmp snakeHeadH
   beq collision
   rts
 left:
-  dec {headL}
-  lda {headL}
+  dec snakeHeadL
+  lda snakeHeadL
   and #$1f
   cmp #$1f
   beq collision
@@ -247,19 +246,19 @@ collision:
 
 drawApple:
   ldy #0
-  lda {random}
-  sta ({appleL}),y
+  lda sysRandom
+  sta (appleL),y
   rts
 
 
 drawSnake:
   ldx #0
   lda #1
-  sta ({headL},x) ; paint head
+  sta (snakeHeadL,x) ; paint head
   
-  ldx {length}
+  ldx snakeLength
   lda #0
-  sta ({headL},x) ; erase end of tail
+  sta (snakeHeadL,x) ; erase end of tail
   rts
 
 

--- a/index.markdown
+++ b/index.markdown
@@ -508,6 +508,29 @@ illustrates how `JSR` and `RTS` can be used together to create modular code.
 Now, let's put all this knowledge to good use, and make a game! We're going to
 be making a really simple version of the classic game 'Snake'.
 
+Even though this will be a simple version, the code will be substantially larger
+than all the previous examples. We will need to keep track of several memory
+locations together for the various aspects of the game. We can still do
+the necessary bookkeeping throughout the program ourselves, as before, but
+on a larger scale that quickly becomes tedious and can also lead to bugs that
+are difficult to spot. Instead we'll now let the assembler do some of the
+mundane work for us.
+
+In this assembler, we can define descriptive constants (or symbols) that represent
+numbers. The rest of the code can then simply use the constants instead of the
+literal number, which immediately makes it obvious what we're dealing with.
+You can use letters, digits and underscores in a name.
+
+Here's an example. Note that immediate operands are still prefixed with a `#`.
+{% include start.html %}
+  define  sysRandom  $fe ; an adress
+  define  a_dozen    $0c ; a constant
+ 
+  LDA sysRandom  ; equivalent to "LDA $fe"
+
+  LDX #a_dozen   ; equivalent to "LDX #$0c"
+{% include end.html %}
+
 The simulator widget below contains the entire source code of the game. I'll
 explain how it works in the following sections.
 

--- a/simulator/assembler.js
+++ b/simulator/assembler.js
@@ -9,6 +9,7 @@
  *  see http://gnu.org/licenses/gpl.html
  */
 
+'use strict';
 
 function SimulatorWidget(node) {
   var $node = $(node);
@@ -224,8 +225,7 @@ function SimulatorWidget(node) {
       return get(addr) + (get(addr + 1) << 8);
     }
 
-    // storeByte() - Poke a byte, don't touch any registers
-
+    // Poke a byte, don't touch any registers
     function storeByte(addr, value) {
       set(addr, value & 0xff);
       if ((addr >= 0x200) && (addr <= 0x5ff)) {
@@ -233,9 +233,9 @@ function SimulatorWidget(node) {
       }
     }
 
-    // storeKeypress() - Store keycode in ZP $ff
+    // Store keycode in ZP $ff
     function storeKeypress(e) {
-      value = e.which;
+      var value = e.which;
       memory.storeByte(0xff, value);
     }
 
@@ -279,7 +279,7 @@ function SimulatorWidget(node) {
     var monitoring = false;
     var executeId;
 
-    //set zero and negative processor flags based on result
+    // Set zero and negative processor flags based on result
     function setNVflags(value) {
       if (value) {
         regP &= 0xfd;
@@ -1483,17 +1483,17 @@ function SimulatorWidget(node) {
       return value;
     }
 
-    // popByte() - Pops a byte
+    // Pops a byte
     function popByte() {
       return(memory.get(regPC++) & 0xff);
     }
 
-    // popWord() - Pops a word using popByte() twice
+    // Pops a little-endian word
     function popWord() {
       return popByte() + (popByte() << 8);
     }
 
-    // runBinary() - Executes the assembled code
+    // Executes the assembled code
     function runBinary() {
       if (codeRunning) {
         // Switch OFF everything
@@ -1532,8 +1532,7 @@ function SimulatorWidget(node) {
       }
     }
 
-    // execute() - Executes one instruction.
-    //             This is the main part of the CPU simulator.
+    // Executes one instruction. This is the main part of the CPU simulator.
     function execute(debugging) {
       if (!codeRunning && !debugging) { return; }
 
@@ -1561,7 +1560,7 @@ function SimulatorWidget(node) {
       }
     }
 
-    // debugExec() - Execute one instruction and print values
+    // Execute one instruction and print values
     function debugExec() {
       //if (codeRunning) {
         execute(true);
@@ -1654,9 +1653,9 @@ function SimulatorWidget(node) {
   function Labels() {
     var labelIndex = [];
 
-    function indexLines(lines) {
+    function indexLines(lines, symbols) {
       for (var i = 0; i < lines.length; i++) {
-        if (!indexLine(lines[i])) {
+        if (!indexLine(lines[i], symbols)) {
           message("**Label already defined at line " + (i + 1) + ":** " + lines[i]);
           return false;
         }
@@ -1664,23 +1663,29 @@ function SimulatorWidget(node) {
       return true;
     }
 
-    // indexLine(line) - extract label if line contains one and calculate position in memory.
-    // Return false if label alread exists.
-    function indexLine(input) {
-      		
+    // Extract label if line contains one and calculate position in memory.
+    // Return false if label already exists.
+    function indexLine(input, symbols) {
+          
       // Figure out how many bytes this instruction takes
       var currentPC = assembler.getCurrentPC();
-      assembler.assembleLine(input); //TODO: find a better way for Labels to have access to assembler
+      assembler.assembleLine(input, 0, symbols); //TODO: find a better way for Labels to have access to assembler
 
       // Find command or label
       if (input.match(/^\w+:/)) {
         var label = input.replace(/(^\w+):.*$/, "$1");
+        
+        if (symbols.lookup(label)) {
+          message("**Label " + label + "is already used as a symbol; please rename one of them**");
+          return false;
+        }
+        
         return push(label + "|" + currentPC);
       }
       return true;
     }
 
-    // push() - Push label to array. Return false if label already exists.
+    // Push label to array. Return false if label already exists.
     function push(name) {
       if (find(name)) {
         return false;
@@ -1689,7 +1694,7 @@ function SimulatorWidget(node) {
       return true;
     }
 
-    // find() - Returns true if label exists.
+    // Returns true if label exists.
     function find(name) {
       var nameAndAddr;
       for (var i = 0; i < labelIndex.length; i++) {
@@ -1701,7 +1706,7 @@ function SimulatorWidget(node) {
       return false;
     }
 
-    // setPC() - Associates label with address
+    // Associates label with address
     function setPC(name, addr) {
       var nameAndAddr;
       for (var i = 0; i < labelIndex.length; i++) {
@@ -1714,7 +1719,7 @@ function SimulatorWidget(node) {
       return false;
     }
 
-    // getPC() - Get address associated with label
+    // Get address associated with label
     function getPC(name) {
       var nameAndAddr;
       for (var i = 0; i < labelIndex.length; i++) {
@@ -1813,12 +1818,11 @@ function SimulatorWidget(node) {
       ["STY", null, 0x84, 0x94, null, 0x8c, null, null, null, null, null, null, null],
       ["---", null, null, null, null, null, null, null, null, null, null, null, null]
     ];
-
-    // assembleCode()
-    // "assembles" the code into memory
+    
+    // Assembles the code into memory
     function assembleCode() {
-	  const BOOTSTRAP_ADDRESS = 0x600;
-	
+      const BOOTSTRAP_ADDRESS = 0x600;
+  
       simulator.reset();
       labels.reset();
       defaultCodePC = BOOTSTRAP_ADDRESS;
@@ -1829,22 +1833,22 @@ function SimulatorWidget(node) {
       var lines = code.split("\n");
       codeAssembledOK = true;
 
-	  message("Preprocessing ...");
-	  preprocess(lines);
+      message("Preprocessing ...");
+      var symbols = preprocess(lines);
 
       message("Indexing labels ...");
       defaultCodePC = BOOTSTRAP_ADDRESS;
-      if (!labels.indexLines(lines)) {
+      if (!labels.indexLines(lines, symbols)) {
         return false;
       }
       labels.displayMessage();
 
       defaultCodePC = BOOTSTRAP_ADDRESS;
       message("Assembling code ...");
-
+      
       codeLen = 0;
       for (var i = 0; i < lines.length; i++) {
-        if (!assembleLine(lines[i], i)) {
+        if (!assembleLine(lines[i], i, symbols)) {
           codeAssembledOK = false;
           break;
         }
@@ -1862,81 +1866,60 @@ function SimulatorWidget(node) {
         var str = lines[i].replace("<", "&lt;").replace(">", "&gt;");
         message("**Syntax error line " + (i + 1) + ": " + str + "**");
         ui.initialize();
-        return;
+        return false;
       }
 
       message("Code assembled successfully, " + codeLen + " bytes.");
+      return true;
     }
 
-	// Sanitize input: remove comments and trim leading/trailing whitespace
-	function sanitize(line) {
-		// remove comments
-        var no_comments = line.replace(/^(.*?);.*/, "$1");
-
-		// trim line
-		return no_comments.replace(/^\s+/, "").replace(/\s+$/, "");
+    // Sanitize input: remove comments and trim leading/trailing whitespace
+    function sanitize(line) {
+      // remove comments
+      var no_comments = line.replace(/^(.*?);.*/, "$1");
+  
+      // trim line
+      return no_comments.replace(/^\s+/, "").replace(/\s+$/, "");
     }
 
-	function preprocess(lines) {
-	  var table = [];
-	  const PREFIX = "__"; // Using a prefix avoids clobbering any predefined properties
-	  
-	  function lookup(key) {
-	    if (table.hasOwnProperty(PREFIX + key))
-			return table[PREFIX + key];
-		else return undefined;
-	  } 
-	  
-	  function add(key, value) {
-	    var existingValue = lookup(key)
-		if (existingValue === undefined) {
-		  table[PREFIX + key] = value;
-		}
-	  }
+    function preprocess(lines) {
+      var table = [];
+      const PREFIX = "__"; // Using a prefix avoids clobbering any predefined properties
       
-	  // First pass: build the substitution table
-	  for (var i = 0; i < lines.length; i++) {
-	    lines[i] = sanitize(lines[i]);
-		var match_data = lines[i].match(/^define\s+(\w+)\s+(.+)/);
-		if (match_data) {
-		  add(match_data[1], sanitize(match_data[2]));
-		  lines[i] = ""; // We're done with this preprocessor directive, so delete it
-		}
-	  }
-	  
-	  // Second pass: perform the substitutions. During a substitution round,
-	  // several symbols can be resolved at once; however, this may in turn
-	  // lead to other unresolved symbols. We can tell that we're done when a
-	  // round didn't cause any new substitutions. To protect against infinite
-	  // substitution loops we'll also put a limit on the number of rounds.
-	  for (var round = 0; round < 15; round++) {
-		var did_any_substitutions = false;
-		
-		for (var i = 0; i < lines.length; i++) {
-		  var input = sanitize(lines[i]);		
-		  var match_data = input.match(/{(\w+)}/);
-		  if (match_data) {
-			var lookupValue = lookup(match_data[1]);
-			if (lookupValue !== undefined) {
-			  lines[i] = input.replace(/{\w+}/, lookupValue); // Remove symbol and its {}
-			  did_any_substitutions = true;
-		    }
-		  }
-		}
-		
-		if (!did_any_substitutions) break; // No more changes detected
-	  }	  
-	}
-	
-    // assembleLine()
-    //
-    // assembles one line of code.  Returns true if it assembled successfully,
-    // false otherwise.
-    function assembleLine(input, lineno) {
+      function lookup(key) {
+        if (table.hasOwnProperty(PREFIX + key)) return table[PREFIX + key];
+        else return undefined;
+      }
+      
+      function add(key, value) {
+        var valueAlreadyExists = table.hasOwnProperty(PREFIX + key)
+        if (!valueAlreadyExists) {
+          table[PREFIX + key] = value;
+        }
+      }
+        
+      // Build the substitution table
+      for (var i = 0; i < lines.length; i++) {
+        lines[i] = sanitize(lines[i]);
+        var match_data = lines[i].match(/^define\s+(\w+)\s+(\S+)/);
+        if (match_data) {
+          add(match_data[1], sanitize(match_data[2]));
+          lines[i] = ""; // We're done with this preprocessor directive, so delete it
+        }
+      }
+      
+      // Callers will only need the lookup function
+      return {
+        lookup: lookup
+      }
+    }
+  
+    // Assembles one line of code.
+    // Returns true if it assembled successfully, false otherwise.
+    function assembleLine(input, lineno, symbols) {
       var label, command, param, addr;
 
       // Find command or label
-
       if (input.match(/^\w+:/)) {
         label = input.replace(/(^\w+):.*$/, "$1");
         if (input.match(/^\w+:[\s]*\w+.*$/)) {
@@ -1949,8 +1932,7 @@ function SimulatorWidget(node) {
         command = input.replace(/^(\w+).*$/, "$1");
       }
 
-      // Blank line?  Return.
-
+      // Nothing to do for blank lines
       if (command === "") {
         return true;
       }
@@ -1976,12 +1958,10 @@ function SimulatorWidget(node) {
 
       if (input.match(/^\w+\s+.*?$/)) {
         param = input.replace(/^\w+\s+(.*?)/, "$1");
+      } else if (input.match(/^\w+$/)) {
+        param = "";
       } else {
-        if (input.match(/^\w+$/)) {
-          param = "";
-        } else {
-          return false;
-        }
+        return false;
       }
 
       param = param.replace(/[ ]/g, "");
@@ -1989,25 +1969,24 @@ function SimulatorWidget(node) {
       if (command === "DCB") {
         return DCB(param);
       }
-
-
       for (var o = 0; o < Opcodes.length; o++) {
         if (Opcodes[o][0] === command) {
           if (checkSingle(param, Opcodes[o][11])) { return true; }
-          if (checkImmediate(param, Opcodes[o][1])) { return true; }
-          if (checkZeroPage(param, Opcodes[o][2])) { return true; }
-          if (checkZeroPageX(param, Opcodes[o][3])) { return true; }
-          if (checkZeroPageY(param, Opcodes[o][4])) { return true; }
-          if (checkAbsoluteX(param, Opcodes[o][6])) { return true; }
-          if (checkAbsoluteY(param, Opcodes[o][7])) { return true; }
-          if (checkIndirect(param, Opcodes[o][8])) { return true; }
-          if (checkIndirectX(param, Opcodes[o][9])) { return true; }
-          if (checkIndirectY(param, Opcodes[o][10])) { return true; }
-          if (checkAbsolute(param, Opcodes[o][5])) { return true; }
+          if (checkImmediate(param, Opcodes[o][1], symbols)) { return true; }
+          if (checkZeroPage(param, Opcodes[o][2], symbols)) { return true; }
+          if (checkZeroPageX(param, Opcodes[o][3], symbols)) { return true; }
+          if (checkZeroPageY(param, Opcodes[o][4], symbols)) { return true; }
+          if (checkAbsoluteX(param, Opcodes[o][6], symbols)) { return true; }
+          if (checkAbsoluteY(param, Opcodes[o][7], symbols)) { return true; }
+          if (checkIndirect(param, Opcodes[o][8], symbols)) { return true; }
+          if (checkIndirectX(param, Opcodes[o][9], symbols)) { return true; }
+          if (checkIndirectY(param, Opcodes[o][10], symbols)) { return true; }
+          if (checkAbsolute(param, Opcodes[o][5], symbols)) { return true; }
           if (checkBranch(param, Opcodes[o][12])) { return true; }
         }
       }
-      return false; // Unknown opcode
+      
+      return false; // Unknown syntax
     }
 
     function DCB(param) {
@@ -2031,8 +2010,72 @@ function SimulatorWidget(node) {
       }
       return true;
     }
+    
+    // Try to parse the given parameter as a byte operand.
+    // Returns the (positive) value if successful, otherwise -1
+    function tryParseByteOperand(param, symbols) {
+      if (param.match(/^\w+$/)) {
+        var lookupVal = symbols.lookup(param); // Substitute symbol by actual value, then proceed
+        if (lookupVal) {
+          param = lookupVal;
+        }
+      }
+      
+      var value;
+    
+      // Is it a hexadecimal operand?
+      var match_data = param.match(/^\$([0-9a-f]{1,2})$/i);
+      if (match_data) {
+        value = parseInt(match_data[1], 16);
+      } else {
+        // Is it a decimal operand?
+        match_data = param.match(/^([0-9]{1,3})$/i);
+        if (match_data) {
+          value = parseInt(match_data[1], 10);
+        }
+      }
+      
+      // Validate range
+      if (value >= 0 && value <= 0xff) {
+        return value;
+      } else {
+        return -1;  
+      }
+    }
+    
+    // Try to parse the given parameter as a word operand.
+    // Returns the (positive) value if successful, otherwise -1
+    function tryParseWordOperand(param, symbols) {
+      if (param.match(/^\w+$/)) {
+        var lookupVal = symbols.lookup(param); // Substitute symbol by actual value, then proceed
+        if (lookupVal) {
+          param = lookupVal;
+        }
+      }
+      
+      var value;
+    
+      // Is it a hexadecimal operand?
+      var match_data = param.match(/^\$([0-9a-f]{3,4})$/i);
+      if (match_data) {
+        value = parseInt(match_data[1], 16);
+      } else {
+        // Is it a decimal operand?
+        match_data = param.match(/^([0-9]{1,5})$/i);
+        if (match_data) {
+          value = parseInt(match_data[1], 10);
+        }
+      }
+      
+      // Validate range
+      if (value >= 0 && value <= 0xffff) {
+        return value;
+      } else {
+        return -1;
+      }
+    }
 
-    // checkBranch() - Commom branch function for all branches (BCC, BCS, BEQ, BNE..)
+    // Common branch function for all branches (BCC, BCS, BEQ, BNE..)
     function checkBranch(param, opcode) {
       var addr;
       if (opcode === null) { return false; }
@@ -2051,24 +2094,21 @@ function SimulatorWidget(node) {
       return true;
     }
 
-    // checkImmediate() - Check if param is immediate and push value
-    function checkImmediate(param, opcode) {
+    // Check if param is immediate and push value
+    function checkImmediate(param, opcode, symbols) {
       var value, label, hilo, addr;
       if (opcode === null) { return false; }
-      if (param.match(/^#\$[0-9a-f]{1,2}$/i)) {
-        pushByte(opcode);
-        value = parseInt(param.replace(/^#\$/, ""), 16);
-        if (value < 0 || value > 255) { return false; }
-        pushByte(value);
-        return true;
+      
+      var match_data = param.match(/^#([\w\$]+)$/i);
+      if (match_data) {
+        var operand = tryParseByteOperand(match_data[1], symbols);
+        if (operand >= 0) {
+          pushByte(opcode);
+          pushByte(operand);
+          return true;
+        }
       }
-      if (param.match(/^#[0-9]{1,3}$/i)) {
-        pushByte(opcode);
-        value = parseInt(param.replace(/^#/, ""), 10);
-        if (value < 0 || value > 255) { return false; }
-        pushByte(value);
-        return true;
-      }
+      
       // Label lo/hi
       if (param.match(/^#[<>]\w+$/)) {
         label = param.replace(/^#[<>](\w+)$/, "$1");
@@ -2091,52 +2131,62 @@ function SimulatorWidget(node) {
           return true;
         }
       }
+      
       return false;
     }
 
-    // checkIndirect() - Check if param is indirect and push value
-    function checkIndirect(param, opcode) {
+    // Check if param is indirect and push value
+    function checkIndirect(param, opcode, symbols) {
       var value;
       if (opcode === null) { return false; }
-      if (param.match(/^\(\$[0-9a-f]{4}\)$/i)) {
-        pushByte(opcode);
-        value = param.replace(/^\(\$([0-9a-f]{4}).*$/i, "$1");
-        if (value < 0 || value > 0xffff) { return false; }
-        pushWord(parseInt(value, 16));
-        return true;
+      
+      var match_data = param.match(/^\(([\w\$]+)\)$/i);
+      if (match_data) {
+        var operand = tryParseWordOperand(match_data[1], symbols);
+        if (operand >= 0) {
+          pushByte(opcode);
+          pushWord(operand);
+          return true;
+        }
       }
       return false;
     }
 
-    // checkIndirectX() - Check if param is indirect X and push value
-    function checkIndirectX(param, opcode) {
+    // Check if param is indirect X and push value
+    function checkIndirectX(param, opcode, symbols) {
       var value;
       if (opcode === null) { return false; }
-      if (param.match(/^\(\$[0-9a-f]{1,2},X\)$/i)) {
-        pushByte(opcode);
-        value = param.replace(/^\(\$([0-9a-f]{1,2}).*$/i, "$1");
-        if (value < 0 || value > 255) { return false; }
-        pushByte(parseInt(value, 16));
-        return true;
+      
+      var match_data = param.match(/^\(([\w\$]+),X\)$/i);
+      if (match_data) {
+        var operand = tryParseByteOperand(match_data[1], symbols);
+        if (operand >= 0) {
+          pushByte(opcode);
+          pushByte(operand);
+          return true;
+        }
       }
       return false;
     }
 
-    // checkIndirectY() - Check if param is indirect Y and push value
-    function checkIndirectY(param, opcode) {
+    // Check if param is indirect Y and push value
+    function checkIndirectY(param, opcode, symbols) {
       var value;
       if (opcode === null) { return false; }
-      if (param.match(/^\(\$[0-9a-f]{1,2}\),Y$/i)) {
-        pushByte(opcode);
-        value = param.replace(/^\([\$]([0-9a-f]{1,2}).*$/i, "$1");
-        if (value < 0 || value > 255) { return false; }
-        pushByte(parseInt(value, 16));
-        return true;
+      
+      var match_data = param.match(/^\(([\w\$]+)\),Y$/i);
+      if (match_data) {
+        var operand = tryParseByteOperand(match_data[1], symbols);
+        if (operand >= 0) {
+          pushByte(opcode);
+          pushByte(operand);
+          return true;
+        }
       }
       return false;
     }
 
-    // checkSingle() - Single-byte opcodes
+    // Check single-byte opcodes
     function checkSingle(param, opcode) {
       if (opcode === null) { return false; }
       // Accumulator instructions are counted as single-byte opcodes
@@ -2145,40 +2195,37 @@ function SimulatorWidget(node) {
       return true;
     }
 
-    // checkZeroPage() - Check if param is ZP and push value
-    function checkZeroPage(param, opcode) {
+    // Check if param is ZP and push value
+    function checkZeroPage(param, opcode, symbols) {
       var value;
       if (opcode === null) { return false; }
-      if (param.match(/^\$[0-9a-f]{1,2}$/i)) {
+
+      var operand = tryParseByteOperand(param, symbols);
+      if (operand >= 0) {
         pushByte(opcode);
-        value = parseInt(param.replace(/^\$/, ""), 16);
-        if (value < 0 || value > 255) { return false; }
-        pushByte(value);
+        pushByte(operand);
         return true;
       }
-      if (param.match(/^[0-9]{1,3}$/i)) {
-        value = parseInt(param, 10);
-        if (value < 0 || value > 255) { return false; }
-        pushByte(opcode);
-        pushByte(value);
-        return true;
-      }
+      
       return false;
     }
 
-    // checkAbsoluteX() - Check if param is ABSX and push value
-    function checkAbsoluteX(param, opcode) {
+    // Check if param is ABSX and push value
+    function checkAbsoluteX(param, opcode, symbols) {
       var number, value, addr;
       if (opcode === null) { return false; }
-      if (param.match(/^\$[0-9a-f]{3,4},X$/i)) {
-        pushByte(opcode);
-        number = param.replace(/^\$([0-9a-f]*),X/i, "$1");
-        value = parseInt(number, 16);
-        if (value < 0 || value > 0xffff) { return false; }
-        pushWord(value);
-        return true;
+      
+      var match_data = param.match(/^([\w\$]+),X$/i);
+      if (match_data) {
+        var operand = tryParseWordOperand(match_data[1], symbols);
+        if (operand >= 0) {
+          pushByte(opcode);
+          pushWord(operand);
+          return true;
+        }
       }
 
+      // it could be a label too..
       if (param.match(/^\w+,X$/i)) {
         param = param.replace(/,X$/i, "");
         pushByte(opcode);
@@ -2188,7 +2235,7 @@ function SimulatorWidget(node) {
           pushWord(addr);
           return true;
         } else {
-          pushWord(0x1234);
+          pushWord(0xffff); // filler, only used while indexing labels
           return true;
         }
       }
@@ -2196,21 +2243,22 @@ function SimulatorWidget(node) {
       return false;
     }
 
-    // checkAbsoluteY() - Check if param is ABSY and push value
-    function checkAbsoluteY(param, opcode) {
+    // Check if param is ABSY and push value
+    function checkAbsoluteY(param, opcode, symbols) {
       var number, value, addr;
       if (opcode === null) { return false; }
-      if (param.match(/^\$[0-9a-f]{3,4},Y$/i)) {
-        pushByte(opcode);
-        number = param.replace(/^\$([0-9a-f]*),Y/i, "$1");
-        value = parseInt(number, 16);
-        if (value < 0 || value > 0xffff) { return false; }
-        pushWord(value);
-        return true;
+      
+      var match_data = param.match(/^([\w\$]+),Y$/i);
+      if (match_data) {
+        var operand = tryParseWordOperand(match_data[1], symbols);
+        if (operand >= 0) {
+          pushByte(opcode);
+          pushWord(operand);
+          return true;
+        }
       }
 
       // it could be a label too..
-
       if (param.match(/^\w+,Y$/i)) {
         param = param.replace(/,Y$/i, "");
         pushByte(opcode);
@@ -2220,98 +2268,88 @@ function SimulatorWidget(node) {
           pushWord(addr);
           return true;
         } else {
-          pushWord(0x1234);
+          pushWord(0xffff); // filler, only used while indexing labels
           return true;
         }
       }
       return false;
     }
 
-    // checkZeroPageX() - Check if param is ZPX and push value
-    function checkZeroPageX(param, opcode) {
+    // Check if param is ZPX and push value
+    function checkZeroPageX(param, opcode, symbols) {
       var number, value;
       if (opcode === null) { return false; }
-      if (param.match(/^\$[0-9a-f]{1,2},X/i)) {
-        pushByte(opcode);
-        number = param.replace(/^\$([0-9a-f]{1,2}),X/i, "$1");
-        value = parseInt(number, 16);
-        if (value < 0 || value > 255) { return false; }
-        pushByte(value);
-        return true;
+      
+      var match_data = param.match(/^([\w\$]+),X$/i);
+      if (match_data) {
+        var operand = tryParseByteOperand(match_data[1], symbols);
+        if (operand >= 0) {
+          pushByte(opcode);
+          pushByte(operand);
+          return true;
+        }
       }
-      if (param.match(/^[0-9]{1,3},X/i)) {
-        pushByte(opcode);
-        number = param.replace(/^([0-9]{1,3}),X/i, "$1");
-        value = parseInt(number, 10);
-        if (value < 0 || value > 255) { return false; }
-        pushByte(value);
-        return true;
-      }
+      
       return false;
     }
 
-    function checkZeroPageY(param, opcode) {
+    // Check if param is ZPY and push value
+    function checkZeroPageY(param, opcode, symbols) {
       var number, value;
       if (opcode === null) { return false; }
-      if (param.match(/^\$[0-9a-f]{1,2},Y/i)) {
-        pushByte(opcode);
-        number = param.replace(/^\$([0-9a-f]{1,2}),Y/i, "$1");
-        value = parseInt(number, 16);
-        if (value < 0 || value > 255) { return false; }
-        pushByte(value);
-        return true;
+      
+      var match_data = param.match(/^([\w\$]+),Y$/i);
+      if (match_data) {
+        var operand = tryParseByteOperand(match_data[1], symbols);
+        if (operand >= 0) {
+          pushByte(opcode);
+          pushByte(operand);
+          return true;
+        }
       }
-      if (param.match(/^[0-9]{1,3},Y/i)) {
-        pushByte(opcode);
-        number = param.replace(/^([0-9]{1,3}),Y/i, "$1");
-        value = parseInt(number, 10);
-        if (value < 0 || value > 255) { return false; }
-        pushByte(value);
-        return true;
-      }
+      
       return false;
     }
 
-    // checkAbsolute() - Check if param is ABS and push value
-    function checkAbsolute(param, opcode) {
+    // Check if param is ABS and push value
+    function checkAbsolute(param, opcode, symbols) {
       var value, number, addr;
       if (opcode === null) { return false; }
-      pushByte(opcode);
-      if (param.match(/^\$[0-9a-f]{3,4}$/i)) {
-        value = parseInt(param.replace(/^\$/, ""), 16);
-        if (value < 0 || value > 0xffff) { return false; }
-        pushWord(value);
-        return true;
+
+      var match_data = param.match(/^([\w\$]+)$/i);
+      if (match_data) {
+        var operand = tryParseWordOperand(match_data[1], symbols);
+        if (operand >= 0) {
+          pushByte(opcode);
+          pushWord(operand);
+          return true;
+        }
       }
-      if (param.match(/^[0-9]{1,5}$/i)) {  // Thanks, Matt!
-        value = parseInt(param, 10);
-        if (value < 0 || value > 0xffff) { return false; }
-        pushWord(value);
-        return(true);
-      }
+
       // it could be a label too..
       if (param.match(/^\w+$/)) {
+        pushByte(opcode);
         if (labels.find(param)) {
           addr = (labels.getPC(param));
           if (addr < 0 || addr > 0xffff) { return false; }
           pushWord(addr);
           return true;
         } else {
-          pushWord(0x1234);
+          pushWord(0xffff); // filler, only used while indexing labels
           return true;
         }
       }
       return false;
     }
 
-    // pushByte() - Push byte to memory
+    // Push a byte to memory
     function pushByte(value) {
       memory.set(defaultCodePC, value & 0xff);
       defaultCodePC++;
       codeLen++;
     }
 
-    // pushWord() - Push a word using pushByte twice
+    // Push a word to memory in little-endian order
     function pushWord(value) {
       pushByte(value & 0xff);
       pushByte((value >> 8) & 0xff);
@@ -2332,7 +2370,7 @@ function SimulatorWidget(node) {
       w.document.close();
     }
 
-    // hexDump() - Dump binary as hex to new window
+    // Dump binary as hex to new window
     function hexdump() {
       openPopup(memory.format(0x600, codeLen), 'Hexdump');
     }
@@ -2524,11 +2562,10 @@ function SimulatorWidget(node) {
     return str.substring(hi, hi + 1) + str.substring(lo, lo + 1);
   }
 
-  // message() - Prints text in the message window
+  // Prints text in the message window
   function message(text) {
     $node.find('.messages code').append(text + '\n').scrollTop(10000);
   }
-
 
   initialize();
 }


### PR DESCRIPTION
Hello Nick,

Thanks for your inspiring tutorial, and especially the Snake6502 program! So far I hadn't really studied the 6502 yet, but I now have to concur: 6502 programming is a lot more fun than x86. And the virtual machine with assembler in JavaScript is an excellent playground. I'm now seriously contemplating to take a stab at Conway's Game of Life.

However, as I worked my way through the Snake6502 code, I found myself constantly referring back to the comments at the top in order to understand what went on. What a shame, I thought -- if you'd just replace all the repeated hardcoded values by symbolic constants, the code instantly becomes a lot more readable. All it needs is a little macro preprocessor.

So, I set to work, and I'm extremely happy with the result contained in this pull request. Symbols can be declared as "define someKey someValue". You can then use "{someKey}" in place of "someValue". Comments are stripped off from defines, so you can freely add comments as usual without causing surprising behaviour upon expansion.

I hope you like it!

Kind regards,

Willem Alexander Hajenius.
