### PR TITLE
Fixes pasting/certain keystrokes not re-enabling assemble button

### DIFF
--- a/simulator/assembler.js
+++ b/simulator/assembler.js
@@ -51,8 +51,8 @@ function SimulatorWidget(node) {
     $node.find('.stepButton').click(simulator.debugExec);
     $node.find('.gotoButton').click(simulator.gotoAddr);
     $node.find('.notesButton').click(ui.showNotes);
-    $node.find('.code').keypress(simulator.stop);
-    $node.find('.code').keypress(ui.initialize);
+    $node.find('.code').on('keypress input', simulator.stop);
+    $node.find('.code').on('keypress input', ui.initialize);
     $(document).keypress(memory.storeKeypress);
   }
 


### PR DESCRIPTION
See #10.

Fixes certain keystrokes in the code editor not triggering the assemble button to be re-enabled (and the simulation stopped, etc.).
