### PR TITLE
Fixes invalid monitor range bug & adds range validation

### DIFF
--- a/simulator/assembler.js
+++ b/simulator/assembler.js
@@ -1563,7 +1563,7 @@ function SimulatorWidget(node) {
         if (!isNaN(start) && !isNaN(length) && start >= 0 && length > 0 && (start + length) <= 65536) {
           monitorNode.html(memory.format(start, length));
         } else {
-          monitorNode.html('Cannot montior this range. Valid ranges are between $0000 and $ffff, inclusive.');
+          monitorNode.html('Cannot monitor this range. Valid ranges are between $0000 and $ffff, inclusive.');
         }
       }
     }

--- a/simulator/assembler.js
+++ b/simulator/assembler.js
@@ -1560,7 +1560,7 @@ function SimulatorWidget(node) {
 
         var monitorNode = $node.find('.monitor code');
 
-        if (!isNaN(start) && !isNaN(length) && start >= 0 && length > 0 && (start + length) <= 65536) {
+        if (!isNaN(start) && !isNaN(length) && start >= 0 && length > 0 && (start + length) <= 0x10000) {
           monitorNode.html(memory.format(start, length));
         } else {
           monitorNode.html('Cannot monitor this range. Valid ranges are between $0000 and $ffff, inclusive.');
@@ -1578,11 +1578,11 @@ function SimulatorWidget(node) {
       $start.removeClass('monitor-invalid');
       $length.removeClass('monitor-invalid');
 
-      if(isNaN(start) || start < 0 || start >= 65536) {
+      if(isNaN(start) || start < 0 || start > 0xffff) {
 
         $start.addClass('monitor-invalid');
 
-      } else if(isNaN(length) || (start + length) > 65536) {
+      } else if(isNaN(length) || (start + length) > 0x10000) {
 
         $length.addClass('monitor-invalid');
       }

--- a/simulator/assembler.js
+++ b/simulator/assembler.js
@@ -48,12 +48,15 @@ function SimulatorWidget(node) {
       ui.toggleMonitor();
       simulator.toggleMonitor();
     });
+    $node.find('.start, .length').blur(simulator.handleMonitorRangeChange);
     $node.find('.stepButton').click(simulator.debugExec);
     $node.find('.gotoButton').click(simulator.gotoAddr);
     $node.find('.notesButton').click(ui.showNotes);
     $node.find('.code').on('keypress input', simulator.stop);
     $node.find('.code').on('keypress input', ui.initialize);
     $(document).keypress(memory.storeKeypress);
+
+    simulator.handleMonitorRangeChange();
   }
 
   function stripText() {
@@ -1554,9 +1557,34 @@ function SimulatorWidget(node) {
       if (monitoring) {
         var start = parseInt($node.find('.start').val(), 16);
         var length = parseInt($node.find('.length').val(), 16);
-        if (start >= 0 && length > 0) {
-          $node.find('.monitor code').html(memory.format(start, length));
+
+        var monitorNode = $node.find('.monitor code');
+
+        if (!isNaN(start) && !isNaN(length) && start >= 0 && length > 0 && (start + length) <= 65536) {
+          monitorNode.html(memory.format(start, length));
+        } else {
+          monitorNode.html('Cannot montior this range. Valid ranges are between $0000 and $ffff, inclusive.');
         }
+      }
+    }
+
+    function handleMonitorRangeChange() {
+
+      var $start  = $node.find('.start'),
+          $length = $node.find('.length'),
+          start   = parseInt($start.val(), 16),
+          length  = parseInt($length.val(), 16);
+
+      $start.removeClass('monitor-invalid');
+      $length.removeClass('monitor-invalid');
+
+      if(isNaN(start) || start < 0 || start >= 65536) {
+
+        $start.addClass('monitor-invalid');
+
+      } else if(isNaN(length) || (start + length) > 65536) {
+
+        $length.addClass('monitor-invalid');
       }
     }
 
@@ -1645,7 +1673,8 @@ function SimulatorWidget(node) {
       gotoAddr: gotoAddr,
       reset: reset,
       stop: stop,
-      toggleMonitor: toggleMonitor
+      toggleMonitor: toggleMonitor,
+      handleMonitorRangeChange: handleMonitorRangeChange
     };
   }
 

--- a/simulator/assembler.js
+++ b/simulator/assembler.js
@@ -1558,9 +1558,11 @@ function SimulatorWidget(node) {
         var start = parseInt($node.find('.start').val(), 16);
         var length = parseInt($node.find('.length').val(), 16);
 
+        var end = start + length - 1;
+
         var monitorNode = $node.find('.monitor code');
 
-        if (!isNaN(start) && !isNaN(length) && start >= 0 && length > 0 && (start + length) <= 0x10000) {
+        if (!isNaN(start) && !isNaN(length) && start >= 0 && length > 0 && end <= 0xffff) {
           monitorNode.html(memory.format(start, length));
         } else {
           monitorNode.html('Cannot monitor this range. Valid ranges are between $0000 and $ffff, inclusive.');
@@ -1573,7 +1575,8 @@ function SimulatorWidget(node) {
       var $start  = $node.find('.start'),
           $length = $node.find('.length'),
           start   = parseInt($start.val(), 16),
-          length  = parseInt($length.val(), 16);
+          length  = parseInt($length.val(), 16),
+          end     = start + length - 1;
 
       $start.removeClass('monitor-invalid');
       $length.removeClass('monitor-invalid');
@@ -1582,7 +1585,7 @@ function SimulatorWidget(node) {
 
         $start.addClass('monitor-invalid');
 
-      } else if(isNaN(length) || (start + length) > 0x10000) {
+      } else if(isNaN(length) || end > 0xffff) {
 
         $length.addClass('monitor-invalid');
       }

--- a/simulator/style.css
+++ b/simulator/style.css
@@ -76,6 +76,11 @@
   display: none;
 }
 
+.monitor-invalid {
+  border: 1px inset #c00;
+  padding: 2px 1px;
+}
+
 .messages {
   margin: 0;
   padding: 6px;


### PR DESCRIPTION
Fixes #16.

Monitor now displays a warning message about an invalid range instead of hanging browser.

Also adds basic validation to monitor start/length inputs. If a negative value is entered for either or if `start + length` is beyond the 6502's 64 KiB of memory, the fields will turn red to indicate the problem.
