### PR TITLE
Color coded monitor for code, PC, read/write, special locations, and display

### DIFF
--- a/_includes/end.html
+++ b/_includes/end.html
@@ -50,5 +50,7 @@ $c: Grey
 $d: Light green
 $e: Light blue
 $f: Light grey
+
+In the monitor, when a byte in memory is read it is displayed in bold. If a byte in memory is written, it is displayed in bold and colored green. The special random byte is pink and the last keypress byte is purple. The memory locations corresponding to the display have a transparent highlight that match their color. The compiled program in memory is highlighted with yellow and the memory location of the PC is colored orange.
     </div>
 </div>

--- a/_includes/widget.html
+++ b/_includes/widget.html
@@ -59,5 +59,7 @@ $c: Grey
 $d: Light green
 $e: Light blue
 $f: Light grey
+
+In the monitor, when a byte in memory is read it is displayed in bold. If a byte in memory is written, it is displayed in bold and colored green. The special random byte is pink and the last keypress byte is purple. The memory locations corresponding to the display have a transparent highlight that match their color. The compiled program in memory is highlighted with yellow and the memory location of the PC is colored orange.
     </div>
 </div>

--- a/simulator/style.css
+++ b/simulator/style.css
@@ -76,6 +76,34 @@
   display: none;
 }
 
+.monitor-code {
+  background: rgba(255, 235, 0, .4);
+}
+
+.monitor-read, .monitor-write {
+  font-weight: bold;
+}
+
+.monitor-read {
+  color: #000;
+}
+
+.monitor-write {
+  color: #080;
+}
+
+.monitor-random {
+  color: #FA33FA;
+}
+
+.monitor-lastkey {
+  color: #8C008C;
+}
+
+.monitor-pc {
+  color: #C86400;
+}
+
 .messages {
   margin: 0;
   padding: 6px;


### PR DESCRIPTION
See #19.

This enhancement adds the following features to the monitor:
- If the last operation retrieved something from memory (not the simulator getting the PC or argument but explicit memory retrieval instruction such as `LDA`), it is bolded in the output
- If the last operation wrote to memory, it is bolded and colored in green in the output
- The part of memory that is the display is indicated by a transparent highlighting that corresponds to the color in that memory location
- The special memory locations, random and last keypress, are colored pink and purple respectively (and when you perform an instruction on either of their values they are bolded)
- The program in memory is highlighted in yellow (and the instruction to which the PC points is colored orange)

I'm also looking into expanding this to highlight the current instruction and the address or literal that accompanies that instruction. 
