### PR TITLE
Fixed circular snake bug

### DIFF
--- a/_includes/snake.html
+++ b/_includes/snake.html
@@ -252,13 +252,13 @@ drawApple:
 
 
 drawSnake:
-  ldx #0
-  lda #1
-  sta (snakeHeadL,x) ; paint head
-  
   ldx snakeLength
   lda #0
   sta (snakeHeadL,x) ; erase end of tail
+
+  ldx #0
+  lda #1
+  sta (snakeHeadL,x) ; paint head
   rts
 
 


### PR DESCRIPTION
Reversed the painting of the head and tail, so that the if they happen to be the same location (circular snake that doesn't impact itself), the head isn't erased and then left as an empty spot that travels through the snake until the snake has moved as far as it's length to cycle out the black spot.

You can easily reproduce the issue by starting the game, eating two apples (making you length 4), then immediately moving three directions either clockwise or counter-clockwise, right after each other, causing you to loop back on yourself.
