### PR TITLE
Fixed monitoring button enable bug

### DIFF
--- a/simulator/assembler.js
+++ b/simulator/assembler.js
@@ -45,7 +45,7 @@ function SimulatorWidget(node) {
       }
     });
     $node.find('.monitoring').change(function () {
-      var state = document.getElementsByClassName('monitoring')[0].checked;
+      var state = this.checked;
       ui.toggleMonitor(state);
       simulator.toggleMonitor(state);
     });


### PR DESCRIPTION
The monitoring callback used to look at the first monitoring button in the page. This meant if you clicked on the third monitoring button in the page, the callback would look at the first monitoring button's state. And it would thus look at the wrong button's state.